### PR TITLE
Don’t use --to when talking to Kitty

### DIFF
--- a/plugin/kitty_navigator.vim
+++ b/plugin/kitty_navigator.vim
@@ -26,12 +26,8 @@ command! KittyNavigateDown     call s:KittyAwareNavigate('j')
 command! KittyNavigateUp       call s:KittyAwareNavigate('k')
 command! KittyNavigateRight    call s:KittyAwareNavigate('l')
 
-if !exists("g:kitty_navigator_listening_on_address")
-  let g:kitty_navigator_listening_on_address = 'unix:/tmp/mykitty'
-endif
-
 function! s:KittyCommand(args)
-  let cmd = 'kitty @ --to ' . g:kitty_navigator_listening_on_address . ' ' . a:args
+  let cmd = 'kitty @ ' . a:args
   return system(cmd)
 endfunction
 


### PR DESCRIPTION
According to https://github.com/kovidgoyal/kitty/issues/1501, Kitty in fact does not require `--listen-on` & `--to` for remote control from child processes.

Since vim-kitty-navigator, I assume, would only ever need to control a Kitty instance from within itself (from within Vim running in one of Kitty’s windows), it seems like it won’t need this flag.

I verified that it works for me after this change.

I’m happy it does, since I’ve started to use multiple Kitty instances and I’d hate to have to set the listen-on address in Vim each time, or muck around with environment variables to automate that.