### PR TITLE
Fix missing arg in send_text in passkeys kitten

### DIFF
--- a/pass_keys.py
+++ b/pass_keys.py
@@ -31,7 +31,7 @@ def handle_result(args, result, target_window_id, boss):
 
     mods, key, is_text = ku.parse_kittens_shortcut(args[3])
     if is_text:
-        w.send_text(key)
+        w.send_text("all", key)
         return
 
     extended = w.screen.extended_keyboard


### PR DESCRIPTION
`send_text` as described in kitty doc's requires two args, mode and text: https://sw.kovidgoyal.net/kitty/conf.html?highlight=send_text#shortcut-kitty.Send-arbitrary-text-on-key-presses

Without this, the kitten fails as such:

> Traceback (most recent call last):
>   File "/usr/bin/../lib/kitty/kitty/boss.py", line 652, in dispatch_special_key
>     return self.dispatch_action(key_action)
>   File "/usr/bin/../lib/kitty/kitty/boss.py", line 714, in dispatch_action
>     passthrough = f(*key_action.args)
>   File "/usr/bin/../lib/kitty/kitty/boss.py", line 935, in kitten
>     self._run_kitten(kitten, kargs)
>   File "/usr/bin/../lib/kitty/kitty/boss.py", line 876, in _run_kitten
>     return end_kitten(None, getattr(w, 'id', None), self)
>   File "/home/dreeves/.config/kitty/pass_keys.py", line 34, in handle_result
>     w.send_text(key)
>   File "/usr/bin/../lib/kitty/kitty/window.py", line 492, in send_text
>     required_mode_, text = args[-2:]
> ValueError: not enough values to unpack (expected 2, got 1)