### PR TITLE
fix: ignore case when searching for title

### DIFF
--- a/pass_keys.py
+++ b/pass_keys.py
@@ -41,7 +41,7 @@ def handle_result(args, result, target_window_id, boss):
             boss.active_tab.neighboring_window(args[2])
             return
     else:
-        if not re.search("n?vim", w.title):
+        if not re.search("n?vim", w.title, re.I):
             boss.active_tab.neighboring_window(args[2])
             return
 


### PR DESCRIPTION
Hi,

I have had problems navigating splits in Neovim.  After some investigation I found it to be because nvim is spelled using uppercase.

This seems to fix the problem.  Thoughts?