### PR TITLE
Fix install instructions to be able to use navigation with multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ map ctrl+l kitten pass_keys.py neighboring_window right  ctrl+l "^.* - nvim$"
 Start kitty with the `listen_on` option so that vim can send commands to it.
 
 ```
-kitty -o allow_remote_control=yes --listen-on unix:/tmp/mykitty
+kitty -o allow_remote_control=yes --single-instance --listen-on unix:@mykitty
 ```
 
-The listening address can be customized in your vimrc by setting `g:kitty_navigator_listening_on_address`. It defaults to `unix:/tmp/mykitty`.
+The listening address can be customized in your vimrc by setting `g:kitty_navigator_listening_on_address`. It defaults to `unix:@mykitty`.
 
 Configuration
 -------------


### PR DESCRIPTION
Changes setup instructions on README.md.
With the setup before this fix, when a new kitty instance is opened, the /tmp/mykitty file is overwritten and the navigation works just in the newer instance, even if you change (alt+tab) to an older instance.

Set output dynamically (change from /tmp/mykitty to @mykitty) prevent the bug, but make impossible create new instances on the same output (/tmp/mykitty).
So pass the parameter --single-instance make able to create dynamic reference for instances, use cache and reduce the startup time.
Doc for --single-instance: https://sw.kovidgoyal.net/kitty/invocation.html#cmdoption-kitty-single-instance