### PR TITLE
Check the first word of the first foreground process rather than the title

### DIFF
--- a/pass_keys.py
+++ b/pass_keys.py
@@ -35,13 +35,14 @@ def handle_result(args, result, target_window_id, boss):
     if w is None:
         return
 
-# 
     if len(args) > 4:
         if not re.search(args[4], w.title):
             boss.active_tab.neighboring_window(args[2])
             return
     else:
-        if not re.search("n?vim", w.title, re.I):
+        # check the first word of the first foreground process
+        foreground_process = w.child.foreground_processes[0]['cmdline'][0]
+        if not re.search("n?vim", foreground_process, re.I):
             boss.active_tab.neighboring_window(args[2])
             return
 


### PR DESCRIPTION
First, thanks for this port of the vim-tmux-navigator! I am currently investigating the option of switching from a tmux-centric setup to a pure kitty-based solution and without this plugin that would have been a major setback..

However, I noticed a major limitation of the vim-instance detection when my current directory name contains a matching string. Since the cwd gets placed into the window title it renders the window switching impossible.
Resolving to checking the `foreground_processes` rather than the `title` seems like a more reasonable solution.