### PR TITLE
fixes #23

### DIFF
--- a/pass_keys.py
+++ b/pass_keys.py
@@ -1,6 +1,8 @@
-from kittens.tui.handler import result_handler
-from kitty.key_encoding import ( KeyEvent, encode_key_event, parse_shortcut )
 import re
+
+from kittens.tui.handler import result_handler
+from kitty.fast_data_types import encode_key_for_tty
+from kitty.key_encoding import KeyEvent, parse_shortcut
 
 
 def is_window_vim(window, vim_id):
@@ -10,9 +12,20 @@ def is_window_vim(window, vim_id):
 
 def encode_key_mapping(key_mapping):
     mods, key = parse_shortcut(key_mapping)
-    ev = KeyEvent(mods=mods, key=key, shift=bool(mods & 1), alt=bool(mods & 2), ctrl=bool(mods & 4),
-            super=bool(mods & 8), hyper=bool(mods & 16), meta=bool(mods & 32))
-    return encode_key_event(ev)
+    event = KeyEvent(
+        mods=mods,
+        key=key,
+        shift=bool(mods & 1),
+        alt=bool(mods & 2),
+        ctrl=bool(mods & 4),
+        super=bool(mods & 8),
+        hyper=bool(mods & 16),
+        meta=bool(mods & 32),
+    ).as_window_system_event()
+
+    return encode_key_for_tty(
+        event.key, event.shifted_key, event.alternate_key, event.mods, event.action
+    )
 
 
 def main():


### PR DESCRIPTION
Reading the code in PR https://github.com/knubie/vim-kitty-navigator/pull/21 it seems before the PR got merged keys were sent to `window.write_to_child` using `encode_key_for_tty`. This got lost in its refactor.

This fix passes a [`as_window_system_event`](https://github.com/kovidgoyal/kitty/blob/88150b2012f30ab1806ff6c011874583b3df8177/kitty/key_encoding.py#L250) to [`encode_key_for_tty`](https://github.com/kovidgoyal/kitty/blob/88150b2012f30ab1806ff6c011874583b3df8177/kitty/fast_data_types.pyi#L282).

If you are able, please test it on other OS's.

---

When running `kitty --debug-keyboard` no error is thrown.

Navigating to windows in vim, and from vim to kitty does not clear navigator keybindings in vim.

PS sorry for the different formatting. This is what my python autofix setup turned it in to.