### PR TITLE
Allow for better isolation by allowing users to define the kittens installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,35 +42,67 @@ Then run
 
 ### kitty
 
+Use one of the following methods:
+
+#### 1. Add a Git Submodule
+
+If you use git to version control your kitty config, the best way to integrate is by adding this repo as a git submodule:
+
+```bash
+git submodule add https://github.com/knubie/vim-kitty-navigator.git ~/.config/kitty/vim-kitty-navigator
+```
+
+Assuming that your `kitty.conf` file is in the `~/.config/kitty` directory, no other configuration is required.
+
+#### 2. Reference the Files in `~/.vim/plugged`
+
+You can reference the kitten files in `~/.vim/plugged` (or your `vim-plug` main directory) for this plugin from `kitty.conf`:
+```
+map ctrl+j kitten ~/.vim/plugged/vim-kitty-navigator/pass_keys.py neighboring_window bottom ctrl+j
+```
+
+However, in order for that to work properly you need to overwrite the `g:kitty_navigator_installation_path` from `.vimrc`:
+
+```vim
+let g:kitty_navigator_installation_path='~/.vim/plugged/vim-kitty-navigator'
+```
+
+#### 3. Copy the `pass_keys.py` and `neighboring_window.py` Kittens
+
 To configure the kitty side of this customization there are three parts:
 
-#### Add `pass_keys.py` and `neighboring_window.py` kittens
+Move both `pass_keys.py` and `neighboring_window.py` kittens to the `~/.config/kitty/`. It can be done manually or with the `vim-plug` post-update hook:
 
-Move both `pass_keys.py` and `neighboring_window.py` kittens to the `~/.config/kitty/`. It can be done manually or with the `vim-plug` post-update hook
 ``` vim
-Plug 'knubie/vim-kitty-navigator', {'do': 'cp ./*.py ~/.config/kitty/'}
+function! BuildKittyNavigator(info) abort
+    !mkdir -p ~/.config/kitty/vim-kitty-navigator
+    !cp ./*.py ~/.config/kitty/vim-kitty-navigator
+endfunction
+Plug 'knubie/vim-kitty-navigator', {'do': function('BuildKittyNavigator')}
 ```
 
 The `pass_keys.py` kitten is used to intercept keybindings defined in your kitty conf and "pass" them through to vim when it is focused. The `neighboring_window.py` kitten is used to send the `neighboring_window` command (e.g. `kitten @ neighboring_window.py right`) from vim when you've reached the last pane and are ready to switch to a non-vim kitty window.
+
+-----
 
 #### Add this snippet to kitty.conf
 
 Add the following to your `~/.config/kitty/kitty.conf` file:
 
 ```conf
-map ctrl+j kitten pass_keys.py neighboring_window bottom ctrl+j
-map ctrl+k kitten pass_keys.py neighboring_window top    ctrl+k
-map ctrl+h kitten pass_keys.py neighboring_window left   ctrl+h
-map ctrl+l kitten pass_keys.py neighboring_window right  ctrl+l
+map ctrl+j kitten path/to/pass_keys.py neighboring_window bottom ctrl+j
+map ctrl+k kitten path/to/pass_keys.py neighboring_window top    ctrl+k
+map ctrl+h kitten path/to/pass_keys.py neighboring_window left   ctrl+h
+map ctrl+l kitten path/to/pass_keys.py neighboring_window right  ctrl+l
 ```
 
 By default `vim-kitty-navigator` uses the name of the current foreground process to detect when it is in a (neo)vim session or not. If that doesn't work, (or if you want to support applications other than vim) you can supply a fourth optional argument to the `pass_keys.py` call in your `kitty.conf` file to match the process name. 
 
 ```conf
-map ctrl+j kitten pass_keys.py neighboring_window bottom ctrl+j "^.* - nvim$"
-map ctrl+k kitten pass_keys.py neighboring_window top    ctrl+k "^.* - nvim$"
-map ctrl+h kitten pass_keys.py neighboring_window left   ctrl+h "^.* - nvim$"
-map ctrl+l kitten pass_keys.py neighboring_window right  ctrl+l "^.* - nvim$"
+map ctrl+j kitten path/to/pass_keys.py neighboring_window bottom ctrl+j "^.* - nvim$"
+map ctrl+k kitten path/to/pass_keys.py neighboring_window top    ctrl+k "^.* - nvim$"
+map ctrl+h kitten path/to/pass_keys.py neighboring_window left   ctrl+h "^.* - nvim$"
+map ctrl+l kitten path/to/pass_keys.py neighboring_window right  ctrl+l "^.* - nvim$"
 ```
 
 #### Make kitty listen to control messages
@@ -111,6 +143,14 @@ nnoremap <silent> {Right-Mapping} :KittyNavigateRight<cr>
 *Note* Each instance of `{Left-Mapping}` or `{Down-Mapping}` must be replaced
 in the above code with the desired mapping. Ie, the mapping for `<ctrl-h>` =>
 Left would be created with `nnoremap <silent> <c-h> :KittyNavigateLeft<cr>`.
+
+### Custom Installation Path
+
+Add the following to your `~/.vimrc` to define the installation path of the kittens:
+
+```vim
+let g:kitty_navigator_installation_path = 'path/to/vim-kitty-navigator-directory'
+```
 
 Troubleshooting
 ---------------

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ let g:kitty_navigator_installation_path='~/.vim/plugged/vim-kitty-navigator'
 
 To configure the kitty side of this customization there are three parts:
 
-Move both `pass_keys.py` and `neighboring_window.py` kittens to the `~/.config/kitty/`. It can be done manually or with the `vim-plug` post-update hook:
+Copy both `pass_keys.py` and `neighboring_window.py` kittens to the `~/.config/kitty/vim-kitty-navigator`. It can be done manually or with the `vim-plug` post-update hook:
 
 ``` vim
 function! BuildKittyNavigator(info) abort

--- a/README.md
+++ b/README.md
@@ -44,30 +44,7 @@ Then run
 
 Use one of the following methods:
 
-#### 1. Add a Git Submodule
-
-If you use git to version control your kitty config, the best way to integrate is by adding this repo as a git submodule:
-
-```bash
-git submodule add https://github.com/knubie/vim-kitty-navigator.git ~/.config/kitty/vim-kitty-navigator
-```
-
-Assuming that your `kitty.conf` file is in the `~/.config/kitty` directory, no other configuration is required.
-
-#### 2. Reference the Files in `~/.vim/plugged`
-
-You can reference the kitten files in `~/.vim/plugged` (or your `vim-plug` main directory) for this plugin from `kitty.conf`:
-```
-map ctrl+j kitten ~/.vim/plugged/vim-kitty-navigator/pass_keys.py neighboring_window bottom ctrl+j
-```
-
-However, in order for that to work properly you need to overwrite the `g:kitty_navigator_installation_path` from `.vimrc`:
-
-```vim
-let g:kitty_navigator_installation_path='~/.vim/plugged/vim-kitty-navigator'
-```
-
-#### 3. Copy the `pass_keys.py` and `neighboring_window.py` Kittens
+#### 1. Copy the `pass_keys.py` and `neighboring_window.py` Kittens
 
 To configure the kitty side of this customization there are three parts:
 
@@ -79,6 +56,33 @@ function! BuildKittyNavigator(info) abort
     !cp ./*.py ~/.config/kitty/vim-kitty-navigator
 endfunction
 Plug 'knubie/vim-kitty-navigator', {'do': function('BuildKittyNavigator')}
+```
+
+#### 2. Add a Git Submodule
+
+If you use git to version control your kitty config, the best way to integrate is by adding this repo as a git submodule:
+
+```bash
+git submodule add https://github.com/knubie/vim-kitty-navigator.git ~/.config/kitty/vim-kitty-navigator
+```
+
+However, in order for that to work properly you need to overwrite the `g:kitty_navigator_installation_path` from `.vimrc`:
+
+```vim
+let g:kitty_navigator_installation_path='./vim-kitty-navigator'
+```
+
+#### 3. Reference the Files in `~/.vim/plugged`
+
+You can reference the kitten files in `~/.vim/plugged` (or your `vim-plug` main directory) for this plugin from `kitty.conf`:
+```
+map ctrl+j kitten ~/.vim/plugged/vim-kitty-navigator/pass_keys.py neighboring_window bottom ctrl+j
+```
+
+However, in order for that to work properly you need to overwrite the `g:kitty_navigator_installation_path` from `.vimrc`:
+
+```vim
+let g:kitty_navigator_installation_path='~/.vim/plugged/vim-kitty-navigator'
 ```
 
 The `pass_keys.py` kitten is used to intercept keybindings defined in your kitty conf and "pass" them through to vim when it is focused. The `neighboring_window.py` kitten is used to send the `neighboring_window` command (e.g. `kitten @ neighboring_window.py right`) from vim when you've reached the last pane and are ready to switch to a non-vim kitty window.

--- a/doc/kitty-navigator.txt
+++ b/doc/kitty-navigator.txt
@@ -18,7 +18,7 @@ NOTE: This requires kitty v0.13.1 or higher.
 ==============================================================================
 CONFIGURATION                             *kitty-navigator-configuration*
 
-* Custom Key Bindings
+* Custom Key Bindings: >
  let g:kitty_navigator_no_mappings = 1
 
  nnoremap <silent> {Left-mapping} :KittyNavigateLeft<cr>
@@ -26,5 +26,15 @@ CONFIGURATION                             *kitty-navigator-configuration*
  nnoremap <silent> {Up-Mapping} :KittyNavigateUp<cr>
  nnoremap <silent> {Right-Mapping} :KittyNavigateRight<cr>
  nnoremap <silent> {Previous-Mapping} :KittyNavigatePrevious<cr>
+<
+
+* Custom installation path:
+This allows you to configure the installation path of the kittens contained in this plugin.
+It can be a relative (to the directory containing `kitty.conf`) or an absolute path.
+Default: `./vim-kitty-navigator`. Assumes that this repo cloned/added as a submodule into the kitty home dir.
+
+>
+ let g:kitty_navigator_installation_path = './path/to/installation'
+<
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/kitty-navigator.txt
+++ b/doc/kitty-navigator.txt
@@ -31,7 +31,8 @@ CONFIGURATION                             *kitty-navigator-configuration*
 * Custom installation path:
 This allows you to configure the installation path of the kittens contained in this plugin.
 It can be a relative (to the directory containing `kitty.conf`) or an absolute path.
-Default: `./vim-kitty-navigator`. Assumes that this repo cloned/added as a submodule into the kitty home dir.
+Default: `./` (assumes that the files were copied to the same directy as
+`kitty.conf`).
 
 >
  let g:kitty_navigator_installation_path = './path/to/installation'

--- a/pass_keys.py
+++ b/pass_keys.py
@@ -43,6 +43,6 @@ def handle_result(args, result, target_window_id, boss):
         return
     if is_window_vim(window, vim_id):
         encoded = encode_key_mapping(key_mapping)
-        window.write_to_child(encoded)
+        window.write_to_child(encoded.encode())
     else:
         boss.active_tab.neighboring_window(direction)

--- a/plugin/kitty_navigator.vim
+++ b/plugin/kitty_navigator.vim
@@ -38,10 +38,6 @@ augroup kitty_navigator
   autocmd WinEnter * let s:kitty_is_last_pane = 0
 augroup END
 
-if !get(g:, 'kitty_navigator_installation_path')
-  let g:kitty_navigator_installation_path = './vim-kitty-navigator'
-endif
-
 " Function: s:path_join(pathparts, {path_separator}) {{{3
 function! s:path_join(pathparts, ...) abort
   let sep
@@ -61,6 +57,8 @@ function! s:KittyAwareNavigate(direction)
   endif
   let at_tab_page_edge = (nr == winnr())
 
+  let installation_path = get(g:, 'kitty_navigator_installation_path', './')
+
   if kitty_last_pane || at_tab_page_edge
     let mappings = {
     \   "h": "left",
@@ -68,7 +66,7 @@ function! s:KittyAwareNavigate(direction)
     \   "k": "top",
     \   "l": "right"
     \ }
-    let args = 'kitten ' . s:path_join([get(g:, 'kitty_navigator_installation_path'), 'neighboring_window.py']) . ' ' . mappings[a:direction]
+    let args = 'kitten ' . s:path_join([installation_path, 'neighboring_window.py']) . ' ' . mappings[a:direction]
     silent call s:KittyCommand(args)
     let s:kitty_is_last_pane = 1
   else

--- a/plugin/kitty_navigator.vim
+++ b/plugin/kitty_navigator.vim
@@ -38,6 +38,21 @@ augroup kitty_navigator
   autocmd WinEnter * let s:kitty_is_last_pane = 0
 augroup END
 
+if !get(g:, 'kitty_navigator_installation_path')
+  let g:kitty_navigator_installation_path = './vim-kitty-navigator'
+endif
+
+" Function: s:path_join(pathparts, {path_separator}) {{{3
+function! s:path_join(pathparts, ...) abort
+  let sep
+        \ = (a:0) == 0                       ? '/'
+        \ : type(a:1)==type(0) && (a:1) == 0 ? '/'
+        \ : (a:1) == 1                       ? '\'
+        \ : (a:1) =~ 'shellslash\|ssl'       ? (&ssl ? '\' : '/')
+        \ :                                    (a:1)
+  return join(a:pathparts, sep)
+endfunction
+
 function! s:KittyAwareNavigate(direction)
   let nr = winnr()
   let kitty_last_pane = (a:direction == 'p' && s:kitty_is_last_pane)
@@ -53,7 +68,7 @@ function! s:KittyAwareNavigate(direction)
     \   "k": "top",
     \   "l": "right"
     \ }
-    let args = 'kitten neighboring_window.py' . ' ' . mappings[a:direction]
+    let args = 'kitten ' . s:path_join([get(g:, 'kitty_navigator_installation_path'), 'neighboring_window.py']) . ' ' . mappings[a:direction]
     silent call s:KittyCommand(args)
     let s:kitty_is_last_pane = 1
   else


### PR DESCRIPTION
The current suggested installation method has some drawbacks if you version control your Kitty configuration.

The plugin also assumes the kittens are installed in the same directory of `kitty.conf`, but this is a very strong assumption.

I usually install kittens as git submodules so they can be properly isolated and automatically upgraded when needed. For that to work, I cannot have the kittens in the same directory as `kitty.conf`, so I nest them into a directory.

The changes proposed here encompass 3 possible installation methods:
1. The git submodule: will add a submodule at `~/.config/kitty/vim-kitty-navigator/` and this location is automatically picked up by the Vim plugin.
2. The `~/.vim/plugged` direct reference: this is to avoid downloading the repo twice (one for `vim-plug`, other for the submodule).
    ```
    # kitty.conf
    map ctrl+j kitten ~/.vim/plugged/vim-kitty-navigator/pass_keys.py neighboring_window bottom ctrl+j
    ```
    ```
    " .vimrc
    let g:kitty_navigator_installation_path='~/.vim/plugged/vim-kitty-navigator'
    ```
3. The copy-pasta: keep the current installation method, only changing the default location to  `~/.config/kitty/vim-kitty-navigator/` to avoid requiring an additional configuration to work.

I'm not that well versed in either Vim Script or Vim help files, so please let me know if there are something that I can improve.