### PR TITLE
Fix failure when `cmdline` is an empty list

### DIFF
--- a/pass_keys.py
+++ b/pass_keys.py
@@ -7,7 +7,7 @@ from kitty.key_encoding import KeyEvent, parse_shortcut
 
 def is_window_vim(window, vim_id):
     fp = window.child.foreground_processes
-    return any(re.search(vim_id, p['cmdline'][0], re.I) for p in fp)
+    return any(re.search(vim_id, p['cmdline'][0] if len(p['cmdline']) else '', re.I) for p in fp)
 
 
 def encode_key_mapping(key_mapping):


### PR DESCRIPTION
After a while of running build scripts in the embedded neovim terminal, kitty's `foreground_processes` list starts getting empty process listings such as this one:
```
{
  "cmdline": [],
  "cwd": null,
   "pid": 3215941
}
```
This breaks line 10 in `pass_keys.py` which is expecting there to always be a first item in the `cmdline` list, causing the keybindings to stop working.