### PR TITLE
Fix 'Key action failed' error on latest kitty version

### DIFF
--- a/pass_keys.py
+++ b/pass_keys.py
@@ -1,7 +1,6 @@
 import re
 
 from kittens.tui.handler import result_handler
-from kitty.fast_data_types import encode_key_for_tty
 from kitty.key_encoding import KeyEvent, parse_shortcut
 
 
@@ -10,7 +9,7 @@ def is_window_vim(window, vim_id):
     return any(re.search(vim_id, p['cmdline'][0] if len(p['cmdline']) else '', re.I) for p in fp)
 
 
-def encode_key_mapping(key_mapping):
+def encode_key_mapping(window, key_mapping):
     mods, key = parse_shortcut(key_mapping)
     event = KeyEvent(
         mods=mods,
@@ -23,9 +22,7 @@ def encode_key_mapping(key_mapping):
         meta=bool(mods & 32),
     ).as_window_system_event()
 
-    return encode_key_for_tty(
-        event.key, event.shifted_key, event.alternate_key, event.mods, event.action
-    )
+    return window.encoded_key(event)
 
 
 def main():
@@ -42,7 +39,7 @@ def handle_result(args, result, target_window_id, boss):
     if window is None:
         return
     if is_window_vim(window, vim_id):
-        encoded = encode_key_mapping(key_mapping)
+        encoded = encode_key_mapping(window, key_mapping)
         window.write_to_child(encoded)
     else:
         boss.active_tab.neighboring_window(direction)


### PR DESCRIPTION
vim-kitty-navigator stops working on latest kitty version compiled from master branch.

The following error message is printed out when navigating splitted window inside Vim.

```
Key action failed

kitten pass_keys.py neighboring_windows right ctrl+l
a bytes-like object is required, not 'str'
```

This PR fixes the above issue.