### PR TITLE
use expand(<sfile>) to lookup python file paths

### DIFF
--- a/plugin/kitty_navigator.vim
+++ b/plugin/kitty_navigator.vim
@@ -5,6 +5,7 @@ if exists("g:loaded_kitty_navigator") || &cp || v:version < 700
   finish
 endif
 let g:loaded_kitty_navigator = 1
+let s:kitty_navigator_directory = expand('<sfile>:p:h:h')
 
 function! s:VimNavigate(direction)
   try
@@ -53,7 +54,8 @@ function! s:KittyAwareNavigate(direction)
     \   "k": "top",
     \   "l": "right"
     \ }
-    let args = 'kitten neighboring_window.py' . ' ' . mappings[a:direction]
+    let neighboring_window_py = s:kitty_navigator_directory .. '/neighboring_window.py'
+    let args = 'kitten ' .. neighboring_window_py .. ' ' . mappings[a:direction]
     silent call s:KittyCommand(args)
     let s:kitty_is_last_pane = 1
   else


### PR DESCRIPTION
The directory a sourced vim file is in can be determined with builtin vim commands, and since the kitten's python files are in git, we can leverage plugin manager functionality rather than using some sort of hook (`do` for `vim-plug`, `run` for `packer.nvim`) to copy or download the files.

Secondly, the `kitty @ kitten` command runs kittens relative to the kitty config directory if it is passed a relative file path, absolute file paths execute the specified file as you would expect with the [working directory of the kitten being inherited from the active window](https://sw.kovidgoyal.net/kitty/kittens/custom/#passing-arguments-to-kittens).

Thus, with these two things in mind the vim plugin can run the kitten from the plugin directory itself. After the user install the vim plugin, the next required step would be to then add the mappings to their kitty config file. Finding the directories plugins are stored in is relatively simple for every plugin manager, and since mappings in `kitty.conf` are static the absolute path of `pass_keys.py` can be used. I use packer.nvim, so here's an example:

```
action_alias pass_keys kitten ~/.local/share/nvim/site/pack/packer/start/vim-kitty-navigator/pass_keys.py
map ctrl+j pass_keys neighboring_window bottom ctrl+j
map ctrl+k pass_keys neighboring_window top    ctrl+k
map ctrl+h pass_keys neighboring_window left   ctrl+h
map ctrl+l pass_keys neighboring_window right  ctrl+l
```

Note: As of publishing this PR, the documentation has not been updated. I will update the readme if/when the implementation passes review.

Let me know if you have any questions!