### PR TITLE
fix: split on > for sequence mappings

### DIFF
--- a/pass_keys.py
+++ b/pass_keys.py
@@ -39,7 +39,6 @@ def handle_result(args, result, target_window_id, boss):
     if window is None:
         return
     if is_window_vim(window, vim_id):
-        # TODO: investigate if splitting on > has side effects
         for keymap in key_mapping.split(">"):
             encoded = encode_key_mapping(window, keymap)
             window.write_to_child(encoded)

--- a/pass_keys.py
+++ b/pass_keys.py
@@ -39,7 +39,9 @@ def handle_result(args, result, target_window_id, boss):
     if window is None:
         return
     if is_window_vim(window, vim_id):
-        encoded = encode_key_mapping(window, key_mapping)
-        window.write_to_child(encoded)
+        # TODO: investigate if splitting on > has side effects
+        for keymap in key_mapping.split(">"):
+            encoded = encode_key_mapping(window, keymap)
+            window.write_to_child(encoded)
     else:
         boss.active_tab.neighboring_window(direction)


### PR DESCRIPTION
This is a draft PR, I had an issue mapping with `ctrl+w>l` syntax. I came up with this approach but have not checked for edge cases or side effects. I'll move out of draft after further investigation or you can pick up as well.

```
map ctrl+w>j kitten pass_keys.py neighboring_window bottom 'ctrl+w>j' nvim
map ctrl+w>k kitten pass_keys.py neighboring_window top    'ctrl+w>k' nvim
map ctrl+w>h kitten pass_keys.py neighboring_window left   'ctrl+w>h' nvim
map ctrl+w>l kitten pass_keys.py neighboring_window right  'ctrl+w>l' nvim
```

Thanks for the kitten! 😸