### PR TITLE
Allow mappings to work, if Kitty is not available

### DIFF
--- a/plugin/kitty_navigator.vim
+++ b/plugin/kitty_navigator.vim
@@ -42,15 +42,23 @@ function! s:KittyCommand(args)
   return system(cmd)
 endfunction
 
-call s:KittyCommand('set-user-vars IS_VIM=true')
+let s:kitty_accessible = 0
+let s:output = s:KittyCommand('set-user-vars IS_VIM=true')
+if v:shell_error == 0
+  let s:kitty_accessible = 1
+else
+  echohl ErrorMsg | echom printf('"kitten @ ..." failed with exit code %s and output: %s', string(v:shell_error), s:output) | echohl None
+endif
 
 let s:kitty_is_last_pane = 0
 
-augroup kitty_navigator
-  au!
-  autocmd WinEnter * let s:kitty_is_last_pane = 0
-  autocmd VimLeavePre * call s:KittyCommand('set-user-vars IS_VIM=false')
-augroup END
+if s:kitty_accessible
+  augroup kitty_navigator
+    au!
+    autocmd WinEnter * let s:kitty_is_last_pane = 0
+    autocmd VimLeavePre * call s:KittyCommand('set-user-vars IS_VIM=false')
+  augroup END
+endif
 
 function! s:KittyIsInStackLayout()
   let json_str = s:KittyCommand('ls --match id:' .. getenv("KITTY_WINDOW_ID"))
@@ -59,6 +67,10 @@ function! s:KittyIsInStackLayout()
 endfunction
 
 function! s:KittyAwareNavigate(direction)
+  if !s:kitty_accessible
+    call s:VimNavigate(a:direction)
+    return
+  endif
   let nr = winnr()
   let kitty_last_pane = (a:direction == 'p' && s:kitty_is_last_pane)
   if !kitty_last_pane


### PR DESCRIPTION
Kitty could be unavailable, if we use another terminal emulator, or if we use SSH and the socket is exposed over SSH.  If Kitty is unavailable, we want mappings like
```vim
nnoremap <silent> <c-h> :KittyNavigateLeft<cr>
```
to work inside of (Neo)Vim, i.e. `:KittyNavigateLeft` should work like `:wincmd l`.

Therefore we check if `kitten @ ...` can access Kitty by looking at the exit code.

I tested this with NeoVim 0.11.6 and Vim 9.2 on Fedora.

When using Vim with a non-Kitty terminal, it blocks quite long on the `system()` call, because `kitten` waits for an answer. NeoVim doesn’t block that long, because it doesn’t pass through the pty to `kitten`’s stdin and `kitten` exists faster.  This could be solved in another iteration by using the async `job_start()` (Vim) or `jobstart()` (NeoVim).